### PR TITLE
Clarifying App Role Assignment

### DIFF
--- a/playfab-docs/features/Insights/connectivity/creating-AAD-app-for-insights.md
+++ b/playfab-docs/features/Insights/connectivity/creating-AAD-app-for-insights.md
@@ -64,6 +64,9 @@ Now we will connect the Azure app to your title database.
    * **Analytics data read access**, to run queries and simple management commands.
    * **Analytics data write access**, to create/drop tables, alter retention policy, ingest data, purge.
 
+> [!NOTE] 
+> Changing the roles for the application is only possible through Roles -> Edit Role Members Menu if you don't want to assign an Email Address to your application 
+
    ![Connectivity Custom Role](media/connectivity-cutom-role.png)
 
    ## Next steps


### PR DESCRIPTION
The Application is created as PF User without an Email Adress. When trying to change roles on the user through the User menu, you will encounter an Error "A Users needs an Email Address" preventing you from changing roles.
The workaround is to use the Roles -> Edit Role Members menu.

We should make sure the documentation reflects this and points users in the right direction when they encounter this.

This was tested by me July 6th 2022